### PR TITLE
make the URL scheme agnostic for external font icon requests

### DIFF
--- a/src/components/bootstrap/bootstrap.scss
+++ b/src/components/bootstrap/bootstrap.scss
@@ -5,7 +5,7 @@
 @import "~bootstrap/scss/grid";
 @import "~bootstrap/scss/type";
 @import "~bootstrap/scss/_jumbotron";
-@import url('https://fonts.googleapis.com/css?family=Josefin+Sans:300,400,400i,700|Josefin+Slab:300,400,400i,700');
+@import url('//fonts.googleapis.com/css?family=Josefin+Sans:300,400,400i,700|Josefin+Slab:300,400,400i,700');
 
 @font-face {
   font-family: 'Canter';


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love PRs and appreciate any help you can offer!

Please make sure the following criteria are met before submitting your pull request.

1. <strong>PR meets the Contributing Guidelines (see above)</strong>
2. Ensure the test suite passes
3. Make sure your code lints
-->

## Related Issue
<!-- Include a link to the issue (e.g. #12) -->
resolves #44 

## Summary of Changes
<!-- Briefly summarize the changes made, lists are also appreciated.  Referencing the related issue as a
"TO DO" checklist is also helpful for reviewers

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated

-->
1.  Fixed font loading bug by making external font bundling scheme agnostic.  This fix will support either HTTP or HTTPS, instead of just HTTPS

### Before
In the bundled output (first line), we can see the HTTPS hardcoded path
<img width="1145" alt="screen shot 2017-11-02 at 2 18 07 pm" src="https://user-images.githubusercontent.com/895923/32343179-0ecf7ac0-bfd9-11e7-8930-380426eb4b05.png">

### After
In the bundled output (first line), we can see the scheme is not specified and the build still worked locally.
<img width="1167" alt="screen shot 2017-11-02 at 2 19 05 pm" src="https://user-images.githubusercontent.com/895923/32343231-2d96ca08-bfd9-11e7-9295-334f29956a58.png">
