### PR TITLE
Fix #94: Add group name to card

### DIFF
--- a/src/components/card-grid/card-grid.spec.jsx
+++ b/src/components/card-grid/card-grid.spec.jsx
@@ -14,6 +14,7 @@ function getMockData(size) {
   return mockEvents.slice(0, size).map((event, index) => {
     return {
       title: event.title || `Mock Title ${index}`,
+      groupName: event.group.name || `Mock Group Name ${index}`,
       body: event.body || `Mock Body ${index}`,
       heading: event.title || `Mock Heading ${index}`,
       link: event.link,

--- a/src/components/card-grid/card-grid.spec.jsx
+++ b/src/components/card-grid/card-grid.spec.jsx
@@ -14,7 +14,7 @@ function getMockData(size) {
   return mockEvents.slice(0, size).map((event, index) => {
     return {
       title: event.title || `Mock Title ${index}`,
-      groupName: event.group.name || `Mock Group Name ${index}`,
+      subtitle: event.group.name || `Mock Subtitle ${index}`,
       body: event.body || `Mock Body ${index}`,
       heading: event.title || `Mock Heading ${index}`,
       link: event.link,

--- a/src/components/card/card.jsx
+++ b/src/components/card/card.jsx
@@ -47,9 +47,9 @@ export default class Card extends React.Component {
             <span className="card-title">{ this.props.title }</span>
           </div>
 
-          {this.props.groupName &&
-          <div className="card-group-container">
-            <span className="card-group-name">{this.props.groupName}</span>
+          {this.props.subtitle &&
+          <div className="card-subtitle-container">
+            <span className="card-subtitle">{this.props.subtitle}</span>
           </div>
           }
         </a>
@@ -85,7 +85,7 @@ export default class Card extends React.Component {
 
 Card.propTypes = {
   title: PropTypes.string.isRequired,
-  groupName: PropTypes.string,
+  subtitle: PropTypes.string,
   body: PropTypes.string.isRequired,
   heading: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,

--- a/src/components/card/card.jsx
+++ b/src/components/card/card.jsx
@@ -46,6 +46,10 @@ export default class Card extends React.Component {
           <div className="card-title-container align-self-end">
             <span className="card-title">{ this.props.title }</span>
           </div>
+
+          <div className="card-group-container">
+            <span className="card-group-name">{ this.props.groupName }</span>
+          </div>
         </a>
 
         <div className="card-info d-flex align-self-end justify-content-between">
@@ -79,6 +83,7 @@ export default class Card extends React.Component {
 
 Card.propTypes = {
   title: PropTypes.string.isRequired,
+  groupName: PropTypes.string.isRequired,
   body: PropTypes.string.isRequired,
   heading: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,

--- a/src/components/card/card.jsx
+++ b/src/components/card/card.jsx
@@ -47,9 +47,11 @@ export default class Card extends React.Component {
             <span className="card-title">{ this.props.title }</span>
           </div>
 
+          {this.props.groupName &&
           <div className="card-group-container">
-            <span className="card-group-name">{ this.props.groupName }</span>
+            <span className="card-group-name">{this.props.groupName}</span>
           </div>
+          }
         </a>
 
         <div className="card-info d-flex align-self-end justify-content-between">
@@ -83,7 +85,7 @@ export default class Card extends React.Component {
 
 Card.propTypes = {
   title: PropTypes.string.isRequired,
-  groupName: PropTypes.string.isRequired,
+  groupName: PropTypes.string,
   body: PropTypes.string.isRequired,
   heading: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -40,6 +40,19 @@ $imgHeight: 233px!important;
   text-overflow: ellipsis;
 }
 
+.card-group-container {
+  background: #355463;
+  font-size: 0.8em;
+  font-weight: normal;
+  text-align: right;
+  padding: .25rem .55rem;
+  color: rgba(246, 205, 77, 0.7);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .card-block {
   padding: .5rem;
   height: 100%;

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -1,124 +1,117 @@
 @import '../bootstrap/bootstrap';
-
 $imgHeight: 233px!important;
-
 .card {
-  font-family: "Josefin Sans", sans-serif;
-  background: none !important;
-  border: none !important;
+    font-family: "Josefin Sans", sans-serif;
+    background: none !important;
+    border: none !important;
 }
 
 .lazyload-wrapper {
-
-  .card-img {
-    border-radius: 0 !important;
-    min-height: $imgHeight;
-    max-height: $imgHeight;
-    object-fit: cover;
-  }
-
-  .fade-appear {
-    opacity: 0.01;
-  }
-
-  .fade-appear.fade-appear-active {
-    opacity: 1;
-    transition: opacity 600ms ease-in; //ms should match the value of transitionAppearTimeout
-  }
+    .card-img {
+        border-radius: 0 !important;
+        min-height: $imgHeight;
+        max-height: $imgHeight;
+        object-fit: cover;
+    }
+    .fade-appear {
+        opacity: 0.01;
+    }
+    .fade-appear.fade-appear-active {
+        opacity: 1;
+        transition: opacity 600ms ease-in; //ms should match the value of transitionAppearTimeout
+    }
 }
 
 .card-title-container {
-  background: $denim;
-  text-align: center;
-  font-weight: 100;
-  font-size: 1.4rem;
-  color: $gold;
-  width: 100%;
-  padding: .55rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+    background: $denim;
+    text-align: center;
+    font-weight: 100;
+    font-size: 1.4rem;
+    color: $gold;
+    width: 100%;
+    padding: .55rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-.card-group-container {
-  background: #355463;
-  font-size: 0.8em;
-  font-weight: normal;
-  text-align: right;
-  padding: .25rem .55rem;
-  color: rgba(246, 205, 77, 0.7);
-  font-style: italic;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.card-subtitle-container {
+    background: #355463;
+    font-size: 0.8em;
+    font-weight: normal;
+    text-align: right;
+    padding: .25rem .55rem;
+    color: rgba(246, 205, 77, 0.7);
+    font-style: italic;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .card-block {
-  padding: .5rem;
-  height: 100%;
+    padding: .5rem;
+    height: 100%;
 }
 
 .card-text {
-  font-size: 1.1rem;
+    font-size: 1.1rem;
 }
 
 .card-info {
-  width: 100%;
-  margin-bottom: 1.5rem;
-  line-height: 2.5;
+    width: 100%;
+    margin-bottom: 1.5rem;
+    line-height: 2.5;
 }
 
 .card-heading {
-  font-size: .9rem;
-  font-weight: bold;
-  line-height: 1.25rem;
-  margin-top: 10px;
+    font-size: .9rem;
+    font-weight: bold;
+    line-height: 1.25rem;
+    margin-top: 10px;
 }
 
 .card-social-share {
-  :hover {
-    cursor: pointer;
-  }
-
-  width: 1.75rem;
-  height: 1.75rem;
-  enable-background: new 0 0 24 24;
-  display: block;
+     :hover {
+        cursor: pointer;
+    }
+    width: 1.75rem;
+    height: 1.75rem;
+    enable-background: new 0 0 24 24;
+    display: block;
 }
 
 .card-social {
-  height: 100%;
-  margin-top: 10px;
-  white-space: nowrap;
-  flex-wrap: nowrap;
-  display: flex;
+    height: 100%;
+    margin-top: 10px;
+    white-space: nowrap;
+    flex-wrap: nowrap;
+    display: flex;
 }
 
 .social-link-fb svg,
 .social-link-tw svg {
-  height: 1.7rem;
-  cursor: pointer;
+    height: 1.7rem;
+    cursor: pointer;
 }
 
 .social-link-fb svg {
-  .st0 {
-    fill: #395898;
-  }
+    .st0 {
+        fill: #395898;
+    }
 }
 
 .social-link-tw svg {
-  .st0 {
-    fill: #2DA1EC;
-  }
+    .st0 {
+        fill: #2DA1EC;
+    }
 }
 
 @include media-breakpoint-down(sm) {
-  .card-heading {
-    font-size: .9rem;
-  }
-
-  .social-link-fb svg,
-  .social-link-tw svg {
-    height: 2rem;
-  }
+    .card-heading {
+        font-size: .9rem;
+    }
+    .social-link-fb svg,
+    .social-link-tw svg {
+        height: 2rem;
+    }
 }

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -1,117 +1,117 @@
 @import '../bootstrap/bootstrap';
 $imgHeight: 233px!important;
 .card {
-    font-family: "Josefin Sans", sans-serif;
-    background: none !important;
-    border: none !important;
+  font-family: "Josefin Sans", sans-serif;
+  background: none !important;
+  border: none !important;
 }
 
 .lazyload-wrapper {
-    .card-img {
-        border-radius: 0 !important;
-        min-height: $imgHeight;
-        max-height: $imgHeight;
-        object-fit: cover;
-    }
-    .fade-appear {
-        opacity: 0.01;
-    }
-    .fade-appear.fade-appear-active {
-        opacity: 1;
-        transition: opacity 600ms ease-in; //ms should match the value of transitionAppearTimeout
-    }
+  .card-img {
+    border-radius: 0 !important;
+    min-height: $imgHeight;
+    max-height: $imgHeight;
+    object-fit: cover;
+  }
+  .fade-appear {
+    opacity: 0.01;
+  }
+  .fade-appear.fade-appear-active {
+    opacity: 1;
+    transition: opacity 600ms ease-in; //ms should match the value of transitionAppearTimeout
+  }
 }
 
 .card-title-container {
-    background: $denim;
-    text-align: center;
-    font-weight: 100;
-    font-size: 1.4rem;
-    color: $gold;
-    width: 100%;
-    padding: .55rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  background: $denim;
+  text-align: center;
+  font-weight: 100;
+  font-size: 1.4rem;
+  color: $gold;
+  width: 100%;
+  padding: .55rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card-subtitle-container {
-    background: #355463;
-    font-size: 0.8em;
-    font-weight: normal;
-    text-align: right;
-    padding: .25rem .55rem;
-    color: rgba(246, 205, 77, 0.7);
-    font-style: italic;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  background: #355463;
+  font-size: 0.8em;
+  font-weight: normal;
+  text-align: right;
+  padding: .25rem .55rem;
+  color: rgba(246, 205, 77, 0.7);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card-block {
-    padding: .5rem;
-    height: 100%;
+  padding: .5rem;
+  height: 100%;
 }
 
 .card-text {
-    font-size: 1.1rem;
+  font-size: 1.1rem;
 }
 
 .card-info {
-    width: 100%;
-    margin-bottom: 1.5rem;
-    line-height: 2.5;
+  width: 100%;
+  margin-bottom: 1.5rem;
+  line-height: 2.5;
 }
 
 .card-heading {
-    font-size: .9rem;
-    font-weight: bold;
-    line-height: 1.25rem;
-    margin-top: 10px;
+  font-size: .9rem;
+  font-weight: bold;
+  line-height: 1.25rem;
+  margin-top: 10px;
 }
 
 .card-social-share {
-     :hover {
-        cursor: pointer;
-    }
-    width: 1.75rem;
-    height: 1.75rem;
-    enable-background: new 0 0 24 24;
-    display: block;
+   :hover {
+    cursor: pointer;
+  }
+  width: 1.75rem;
+  height: 1.75rem;
+  enable-background: new 0 0 24 24;
+  display: block;
 }
 
 .card-social {
-    height: 100%;
-    margin-top: 10px;
-    white-space: nowrap;
-    flex-wrap: nowrap;
-    display: flex;
+  height: 100%;
+  margin-top: 10px;
+  white-space: nowrap;
+  flex-wrap: nowrap;
+  display: flex;
 }
 
 .social-link-fb svg,
 .social-link-tw svg {
-    height: 1.7rem;
-    cursor: pointer;
+  height: 1.7rem;
+  cursor: pointer;
 }
 
 .social-link-fb svg {
-    .st0 {
-        fill: #395898;
-    }
+  .st0 {
+    fill: #395898;
+  }
 }
 
 .social-link-tw svg {
-    .st0 {
-        fill: #2DA1EC;
-    }
+  .st0 {
+    fill: #2DA1EC;
+  }
 }
 
 @include media-breakpoint-down(sm) {
-    .card-heading {
-        font-size: .9rem;
-    }
-    .social-link-fb svg,
-    .social-link-tw svg {
-        height: 2rem;
-    }
+  .card-heading {
+    font-size: .9rem;
+  }
+  .social-link-fb svg,
+  .social-link-tw svg {
+    height: 2rem;
+  }
 }

--- a/src/components/card/card.spec.jsx
+++ b/src/components/card/card.spec.jsx
@@ -105,6 +105,7 @@ describe('Card component', () => {
     it('should test the subtitle displays correctly', () => {
       const subtitle = card.find('.card-subtitle-container');
 
+      expect(subtitle).toHaveLength(1);
       expect(subtitle.text()).toEqual(mockCardContent.group.name);
     });
   });
@@ -131,6 +132,12 @@ describe('Card component', () => {
 
       expect(card.find('.twitter-share').prop('href')).toEqual(`https://twitter.com/intent/tweet?status=${message}`);
       expect(card.find(TwitterIcon).length).toEqual(1);
+    });
+
+    it('should test the subtitle does not display', () => {
+      const subtitle = card.find('.card-subtitle-container');
+
+      expect(subtitle).toHaveLength(0);
     });
   });
 

--- a/src/components/card/card.spec.jsx
+++ b/src/components/card/card.spec.jsx
@@ -20,6 +20,7 @@ describe('Card component', () => {
   beforeEach(() => {
     card = mount(<Card
       title={ `${mockCardContent.name}` }
+      groupName={`${mockCardContent.group.name}`}
       body={ `${mockCardContent.description}`}
       heading={ `Heading: ${mockCardContent.name}!!!` }
       link={ mockCardContent.link }
@@ -99,6 +100,12 @@ describe('Card component', () => {
       const body = card.find('.card-text');
 
       expect(body.text()).toEqual('No Description Available.');
+    });
+
+    it('should test the group name displays correctly', () => {
+      const group = card.find('.card-group-container');
+
+      expect(group.text()).toContain(mockCardContent.group.name);
     });
   });
 

--- a/src/components/card/card.spec.jsx
+++ b/src/components/card/card.spec.jsx
@@ -20,7 +20,7 @@ describe('Card component', () => {
   beforeEach(() => {
     card = mount(<Card
       title={ `${mockCardContent.name}` }
-      groupName={`${mockCardContent.group.name}`}
+      subtitle={`${mockCardContent.group.name}`}
       body={ `${mockCardContent.description}`}
       heading={ `Heading: ${mockCardContent.name}!!!` }
       link={ mockCardContent.link }
@@ -102,10 +102,10 @@ describe('Card component', () => {
       expect(body.text()).toEqual('No Description Available.');
     });
 
-    it('should test the group name displays correctly', () => {
-      const group = card.find('.card-group-container');
+    it('should test the subtitle displays correctly', () => {
+      const subtitle = card.find('.card-subtitle-container');
 
-      expect(group.text()).toContain(mockCardContent.group.name);
+      expect(subtitle.text()).toEqual(mockCardContent.group.name);
     });
   });
 

--- a/src/components/events-list/events-list.jsx
+++ b/src/components/events-list/events-list.jsx
@@ -30,6 +30,7 @@ export default class EventsList extends React.Component {
     return eventsResponse.map((event) => {
       return {
         title: event.name,
+        groupName: event.group.name,
         body: Card.formatHtmlContent(event.description || 'No Description Available'),
         heading: EventsList.formatHeading(event),
         link: event.link,

--- a/src/components/events-list/events-list.jsx
+++ b/src/components/events-list/events-list.jsx
@@ -30,7 +30,7 @@ export default class EventsList extends React.Component {
     return eventsResponse.map((event) => {
       return {
         title: event.name,
-        groupName: event.group.name,
+        subtitle: event.group.name,
         body: Card.formatHtmlContent(event.description || 'No Description Available'),
         heading: EventsList.formatHeading(event),
         link: event.link,

--- a/src/components/events-list/events-list.spec.jsx
+++ b/src/components/events-list/events-list.spec.jsx
@@ -82,8 +82,8 @@ describe('EventsList component', () => {
       expect(modeledData.twitterShareMessage).toEqual(`${ mockEvent.name } - ${ mockEvent.link } ! @ProvidenceGeeks`);
     });
 
-    it('should test groupName', () => {
-      expect(modeledData.groupName).toEqual(mockEvent.group.name);
+    it('should test subtitle', () => {
+      expect(modeledData.subtitle).toEqual(mockEvent.group.name);
     });
 
   });

--- a/src/components/events-list/events-list.spec.jsx
+++ b/src/components/events-list/events-list.spec.jsx
@@ -82,6 +82,10 @@ describe('EventsList component', () => {
       expect(modeledData.twitterShareMessage).toEqual(`${ mockEvent.name } - ${ mockEvent.link } ! @ProvidenceGeeks`);
     });
 
+    it('should test groupName', () => {
+      expect(modeledData.groupName).toEqual(mockEvent.group.name);
+    });
+
   });
 
   describe('EventsList.formatHeading', () => {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love PRs and appreciate any help you can offer!

Please make sure the following criteria are met before submitting your pull request.

1. <strong>PR meets the Contributing Guidelines (see above)</strong>
2. Ensure the test suite passes
3. Make sure your code lints
-->

## Related Issue
<!-- Include a link to the issue (e.g. #12) -->
Fix #94 
## Summary of Changes
<!-- Briefly summarize the changes made, lists are also appreciated.  Referencing the related issue as a
"TO DO" checklist is also helpful for reviewers

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated

-->
1. Update the Card component to accept a `groupName` property
1. Update the Event List component to provide event group name to Card component
1. Test that the Card would display the group name properly
1. Style the group name with best-guess colors, etc. (willing to update, if necessary)

EDIT:
Additional notes:
- The group name will not wrap to a multiple lines, but instead will be trimmed and an ellipsis added (screenshot 2 below). This is similar to how the event title is trimmed (screenshot 1 below).
- Screen shots added below for an example of the UI

**Screenshots**
<img width="864" alt="screen shot 2017-12-13 at 1 14 38 pm" src="https://user-images.githubusercontent.com/12274057/33997278-ddb6307e-e0b1-11e7-8ad6-d0213d604353.png">
<img width="347" alt="screen shot 2017-12-13 at 1 14 55 pm" src="https://user-images.githubusercontent.com/12274057/33997279-ddc2f430-e0b1-11e7-9dc5-bab1e104a31d.png">
