### PR TITLE
use different image to support critical dependency on puppeteer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,6 @@ jobs:
           - v1-dependencies-
 
       - run:
-          name: Install Yarn
-          command: sudo npm install -g yarn@^1.0.0
-
-      - run:
           name: Install Project Dependencies
           command: yarn install
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: thegreenhouseio/nodejs-dev:0.2.0
+      - image: thegreenhouse/nodejs-dev:0.2.0
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.9.4
+      - image: thegreenhouseio/nodejs-dev:0.2.0
 
     working_directory: ~/repo
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love PRs and appreciate any help you can offer!

Please make sure the following criteria are met before submitting your pull request.

1. <strong>PR meets the Contributing Guidelines (see above)</strong>
2. Ensure the test suite passes
3. Make sure your code lints
-->

## Related Issue
resolves #143 

## Summary of Changes
<!-- Briefly summarize the changes made, lists are also appreciated.  Referencing the related issue as a
"TO DO" checklist is also helpful for reviewers

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated

-->

Since **critical** (a dependency of **html-critical-webpack-plugin**) expected a headless chrome compatible build environment, this updates CircleCi to use a Docker image that has NodeJS 8.x and Headless Chrome compatible O.S. packages.

This should  result in complete builds, not silently failing builds like observed in the issue.