### PR TITLE
remove extraneous webpack plugin for prod

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -6,7 +6,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const path = require('path');
 const WebpackPwaManifest = require('webpack-pwa-manifest');
-const webpack = require('webpack');
 const UglifyJsWebpackPlugin = require('uglifyjs-webpack-plugin');
 const webpackMerge = require('webpack-merge');
 
@@ -100,8 +99,6 @@ module.exports = webpackMerge(commonConfig, {
       dest: 'index.html',
       inline: true
     }),
-
-    new webpack.optimize.ModuleConcatenationPlugin(),
 
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love PRs and appreciate any help you can offer!

Please make sure the following criteria are met before submitting your pull request.

1. <strong>PR meets the Contributing Guidelines (see above)</strong>
2. Ensure the test suite passes
3. Make sure your code lints
-->

## Related Issue
<!-- Include a link to the issue (e.g. #12) -->
resolves #156 

## Summary of Changes
<!-- Briefly summarize the changes made, lists are also appreciated.  Referencing the related issue as a
"TO DO" checklist is also helpful for reviewers

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated

-->
1.  Removed **ModuleConcatentationPlugin** since it is redundant when also [setting `mode` to `'production'`](https://webpack.js.org/concepts/mode/#mode-production) with **webpack**

Same results before and after (JS bundling wise)
### Before
<img width="1422" alt="with-module-concat" src="https://user-images.githubusercontent.com/895923/39664082-f1509d86-504b-11e8-9f59-f5980b7268db.png">

### After
<img width="1431" alt="without-module-concat" src="https://user-images.githubusercontent.com/895923/39664083-f684c37c-504b-11e8-8191-1c521d27f5c0.png">
