### PR TITLE
use local offset from meetup.com

### DIFF
--- a/src/components/events-list/events-list.jsx
+++ b/src/components/events-list/events-list.jsx
@@ -44,7 +44,7 @@ export default class EventsList extends React.Component {
   }
 
   static formatHeading(event) {
-    const time = event && event.time ? DateFormatterService.formatTimestampForEvents(event.time) : '';
+    const time = event && event.time ? DateFormatterService.formatTimestampForEvents(event.time, event.utc_offset) : '';
     const venue = event && event.venue && event.venue.city ? `@ ${event.venue.city}` : '';
 
     return `${time} ${venue}`;

--- a/src/services/date-formatter/date-formatter-service.js
+++ b/src/services/date-formatter/date-formatter-service.js
@@ -1,6 +1,10 @@
-function getLocalDate(timestamp) {
-  const utcDateObj = new Date(timestamp); // remember, JavaScript dates are localized to the user but reflected in UTC time...
-  const OFFSET_MILLIS = new Date().getTimezoneOffset() * 60 * 1000; // get the local offset
+function getLocalDate(timestamp, utcOffset) {
+  // remember, JavaScript dates are localized to the user but reflected in UTC time...
+  // so we use the offset (from Meetup.com) if provided, other use local browser time
+  const utcDateObj = new Date(timestamp);
+  const OFFSET_MILLIS = utcOffset
+    ? utcOffset
+    : new Date().getTimezoneOffset() * 60 * 1000;
 
   return new Date(utcDateObj.getTime() - OFFSET_MILLIS);
 }
@@ -24,8 +28,8 @@ function getFormattedTime(dateObj) {
 class DateFormatterService {
 
   // example: 05/25/18 6:00PM
-  static formatTimestampForEvents(timestamp) {
-    const eventDateObj = getLocalDate(timestamp);
+  static formatTimestampForEvents(timestamp, offset) {
+    const eventDateObj = getLocalDate(timestamp, Math.abs(offset));
 
     return `${getFormattedDate(eventDateObj)} ${getFormattedTime(eventDateObj)}`;
   }

--- a/src/services/date-formatter/date-formatter-service.js
+++ b/src/services/date-formatter/date-formatter-service.js
@@ -6,7 +6,7 @@ function getLocalDate(timestamp, utcOffset) {
     ? utcOffset
     : new Date().getTimezoneOffset() * 60 * 1000;
 
-  return new Date(utcDateObj.getTime() - OFFSET_MILLIS);
+  return new Date(utcDateObj.getTime() + OFFSET_MILLIS);
 }
 
 function getFormattedDate(dateObj) {
@@ -29,7 +29,7 @@ class DateFormatterService {
 
   // example: 05/25/18 6:00PM
   static formatTimestampForEvents(timestamp, offset) {
-    const eventDateObj = getLocalDate(timestamp, Math.abs(offset));
+    const eventDateObj = getLocalDate(timestamp, offset);
 
     return `${getFormattedDate(eventDateObj)} ${getFormattedTime(eventDateObj)}`;
   }

--- a/src/services/date-formatter/date-formatter-service.spec.js
+++ b/src/services/date-formatter/date-formatter-service.spec.js
@@ -21,6 +21,15 @@ describe('DateFormatterService', () => {
       
       done();
     });
+
+    it('should test mock events dates are formatted correctly - with provided offset', (done) => {
+      const time = mockEvents[3].time;
+      const offset = mockEvents[3].utc_offset;
+
+      expect(DateFormatterService.formatTimestampForEvents(time, offset)).toMatch(DATE_TIME_REGEX);
+      
+      done();
+    });
   });
 
   describe('formatTimestampForBlogPosts', () => {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love PRs and appreciate any help you can offer!

Please make sure the following criteria are met before submitting your pull request.

1. <strong>PR meets the Contributing Guidelines (see above)</strong>
2. Ensure the test suite passes
3. Make sure your code lints
-->

## Related Issue
resolves #179 

## Summary of Changes
1. Add optional `offset` for `DateFormatterService.formatTimestampForEvents` and `getLocalDate`


*Events Local (at the time)*
<img width="1613" alt="events-local" src="https://user-images.githubusercontent.com/895923/55442884-75aca600-557e-11e9-914f-655011d9d387.png">

*Events Prod (at the time)*
<img width="1614" alt="events-prod" src="https://user-images.githubusercontent.com/895923/55442889-78a79680-557e-11e9-8f8a-30f682da7f88.png">
