### PR TITLE
Fix #152: Use `font-display` property to render fallback font

### DIFF
--- a/src/components/bootstrap/bootstrap.scss
+++ b/src/components/bootstrap/bootstrap.scss
@@ -7,17 +7,19 @@
 @import "~bootstrap/scss/_jumbotron";
 @import "~bootstrap/scss/_nav";
 @import "~bootstrap/scss/_card";
-@import url('//fonts.googleapis.com/css?family=Josefin+Sans:300,400,400i,700|Josefin+Slab:300,400,400i,700');
+@import url('//fonts.googleapis.com/css?family=Josefin+Sans:300,400,400i,700|Josefin+Slab:300,400,400i,700&display=swap');
 
 @font-face {
   font-family: 'Canter';
   src: url('../../components/bootstrap/fonts/canter-bold.otf') format('opentype');
   font-weight: bold;
+  font-display: swap;
 }
 
 @font-face {
   font-family: 'Canter';
   src: url('../../components/bootstrap/fonts/canter-light.otf') format('opentype');
+  font-display: swap;
 }
 
 $white: rgb(255, 255, 255);

--- a/src/components/card-grid/card-grid.jsx
+++ b/src/components/card-grid/card-grid.jsx
@@ -13,8 +13,8 @@ export default class CardGrid extends React.Component {
     this.state = this.modelInitStateFromDataProp(props.data);
   }
 
-  componentWillReceiveProps(nextProps) {
-    const state = this.modelInitStateFromDataProp(nextProps.data);
+  UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
+    const state = this.modelInitStateFromDataProp(nextProps.data); 
 
     this.setState(state);
   }

--- a/src/components/card-grid/card-grid.jsx
+++ b/src/components/card-grid/card-grid.jsx
@@ -13,8 +13,8 @@ export default class CardGrid extends React.Component {
     this.state = this.modelInitStateFromDataProp(props.data);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) { // eslint-disable-line camelcase
-    const state = this.modelInitStateFromDataProp(nextProps.data); 
+  componentWillReceiveProps(nextProps) {
+    const state = this.modelInitStateFromDataProp(nextProps.data);
 
     this.setState(state);
   }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love PRs and appreciate any help you can offer!

Please make sure the following criteria are met before submitting your pull request.

1. <strong>PR meets the Contributing Guidelines (see above)</strong>
2. Ensure the test suite passes
3. Make sure your code lints
-->

## Related Issue
<!-- Include a link to the issue (e.g. #12) -->
Fix #152 
## Summary of Changes
<!-- Briefly summarize the changes made, lists are also appreciated.  Referencing the related issue as a
"TO DO" checklist is also helpful for reviewers

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated

-->
Not sure if the Lighthouse audits have change, but the errors I'm seeing that refer to fonts mention the `font-display` property (screenshot below) and are a bit different than the ones mentioned in the issue description. I'm wondering if the audits and/or reports have changed to suggest a specific solution rather? 🤷‍♂ 

When I test this locally using `yarn run serve`, the error is gone and I see a ~100ms difference in the load time, but I know that's not a direct 1:1 to `stage` or `www`.

**Part of report mentioning font rendering:**
![Screen Shot 2019-10-11 at 9 30 53 PM](https://user-images.githubusercontent.com/8385375/66692645-73827d00-ec6e-11e9-93d2-7347e8631630.png)
