### PR TITLE
[Issue-189] Load blogPosts component only when clicked <Anusha>

### DIFF
--- a/src/components/navigation-bar/navigation-bar.jsx
+++ b/src/components/navigation-bar/navigation-bar.jsx
@@ -12,7 +12,7 @@ const NavigationBar = (props) => {
           {
             props.children.map((child, key) => {
               return (
-                <Tab key={key} eventKey={key} title={child.props.title} className="custom-tab-content">
+                <Tab mountOnEnter key={key} eventKey={key} title={child.props.title} className="custom-tab-content">
                   {child}
                 </Tab>
               );

--- a/src/components/navigation-bar/navigation-bar.jsx
+++ b/src/components/navigation-bar/navigation-bar.jsx
@@ -12,7 +12,12 @@ const NavigationBar = (props) => {
           {
             props.children.map((child, key) => {
               return (
-                <Tab mountOnEnter key={key} eventKey={key} title={child.props.title} className="custom-tab-content">
+                <Tab 
+                  key={key} 
+                  eventKey={key} 
+                  title={child.props.title} 
+                  className="custom-tab-content"
+                  mountOnEnter={true}>
                   {child}
                 </Tab>
               );

--- a/src/components/navigation-bar/navigation-bar.spec.jsx
+++ b/src/components/navigation-bar/navigation-bar.spec.jsx
@@ -69,7 +69,6 @@ describe('Navigation Bar component', () => {
     tabChildren.forEach((tab) => {
       expect(tab.props.mountOnEnter).toEqual(true);
     });
-    expect(tabChildren[1].props.mountOnEnter).toEqual(true);
   });
 
   it('should test that no custom title is present if not provided', () => {

--- a/src/components/navigation-bar/navigation-bar.spec.jsx
+++ b/src/components/navigation-bar/navigation-bar.spec.jsx
@@ -64,6 +64,12 @@ describe('Navigation Bar component', () => {
     expect(tabContent.props.title).toEqual('Custom Title 1');
   });
 
+  it('should have mountOnEnter prop set for every tab', () => {
+    const tabChildren = navigationBar.find(Tabs).props().children;
+    expect(tabChildren[0].props.mountOnEnter).toEqual(true);
+    expect(tabChildren[1].props.mountOnEnter).toEqual(true);
+  });
+
   it('should test that no custom title is present if not provided', () => {
     navigationBar = mount(
       <NavigationBar>

--- a/src/components/navigation-bar/navigation-bar.spec.jsx
+++ b/src/components/navigation-bar/navigation-bar.spec.jsx
@@ -66,7 +66,9 @@ describe('Navigation Bar component', () => {
 
   it('should have mountOnEnter prop set for every tab', () => {
     const tabChildren = navigationBar.find(Tabs).props().children;
-    expect(tabChildren[0].props.mountOnEnter).toEqual(true);
+    tabChildren.forEach((tab) => {
+      expect(tab.props.mountOnEnter).toEqual(true);
+    });
     expect(tabChildren[1].props.mountOnEnter).toEqual(true);
   });
 

--- a/src/views/home/home.spec.jsx
+++ b/src/views/home/home.spec.jsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { mount, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import { Tabs } from 'react-bootstrap';
 import BlogPostsList from '../../components/blog-posts-list/blog-posts-list';
 import EventsList from '../../components/events-list/events-list';
 import HeroBanner from '../../components/hero-banner/hero-banner';

--- a/src/views/home/home.spec.jsx
+++ b/src/views/home/home.spec.jsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { mount, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { Tabs } from 'react-bootstrap';
 import BlogPostsList from '../../components/blog-posts-list/blog-posts-list';
 import EventsList from '../../components/events-list/events-list';
 import HeroBanner from '../../components/hero-banner/hero-banner';
@@ -44,6 +45,6 @@ describe('Home View component', () => {
   });
 
   it('should have a BlogPostsList component', () => {
-    expect(home.find(BlogPostsList).length).toEqual(1);
+    expect(home.find(NavigationBar).find(BlogPostsList)).toBeTruthy();
   });
 });

--- a/src/views/home/home.spec.jsx
+++ b/src/views/home/home.spec.jsx
@@ -43,7 +43,7 @@ describe('Home View component', () => {
     expect(home.find(EventsList).length).toEqual(1);
   });
 
-  it('should have a BlogPostsList component', () => {
-    expect(home.find(NavigationBar).find(BlogPostsList)).toBeTruthy();
+  it('should not mount a BlogPostsList component', () => {
+    expect(home.find(BlogPostsList).length).toEqual(0);
   });
 });

--- a/src/views/home/home.spec.jsx
+++ b/src/views/home/home.spec.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { mount, configure } from 'enzyme';
+import { mount, configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import BlogPostsList from '../../components/blog-posts-list/blog-posts-list';
 import EventsList from '../../components/events-list/events-list';
@@ -45,5 +45,10 @@ describe('Home View component', () => {
 
   it('should not mount a BlogPostsList component', () => {
     expect(home.find(BlogPostsList).length).toEqual(0);
+  });
+
+  it('should have a BlogPostsList component', () => {
+    const home = shallow(<Home />);
+    expect(home.find(BlogPostsList).length).toEqual(1);
   });
 });


### PR DESCRIPTION
Hi, could you please review these changes. Have tested, a call to /posts is made only when BlogPosts is clicked.

## Related Issue
https://github.com/ProvidenceGeeks/website-frontend/issues/189

## Summary of Changes
1. Added mountOnEnter Property for tab component
2. Added corresponding tests cases for Navigation bar component
